### PR TITLE
Use $YARN instead of $TOKEN

### DIFF
--- a/src/components/Homapage/collections.json
+++ b/src/components/Homapage/collections.json
@@ -10,7 +10,7 @@
   {
     "title": "Purrnelope's Exclusives",
     "href": "/collections/exclusives",
-    "description": "$TOKEN Yielding NFT",
+    "description": "$YARN Yielding NFT",
     "tier": null,
     "imageUrl": "/img/collection-exclusives.jpg"
   },

--- a/src/pages/contribute.md
+++ b/src/pages/contribute.md
@@ -44,3 +44,4 @@ List of contributors with identity, sorted by the time of first contribution add
 
 - curatorcat.pcc.eth [GitHub](https://github.com/CuratorCat) [Twitter](https://twitter.com/CuratorCatPCC)
 - dodo.pcc.eth [GitHub](https://github.com/dodo-pcc) [Twitter](https://twitter.com/tzh90)
+- hoanh.pcc.eth [GitHub](https://github.com/hoanhan101) [Twitter](https://twitter.com/hoanhan101)

--- a/wiki/club/index.md
+++ b/wiki/club/index.md
@@ -21,17 +21,17 @@ import KVPurrks from '../collections/\_kittyvault-purrks.md';
 
 [^1]: Quoted from PCC first blog post: [Welcome to Purrnelope’s Country Club](/posts/2021/07/14/post/welcome-to-pcc)
 
-Carlini8 is the founder of PCC. PCC has 3 companies[^2]. One original company in the UK registered back in June 2021 for paying the team's salary and taxes[^3]. Another company in BVI registered in December 2021 for PCC to launch its $TOKEN legally in the coming future[^4]. **[The PCC Team](./team.md)** currently consists of 8 full-time members of staff and 2 part-time members of staff.
+Carlini8 is the founder of PCC. PCC has 3 companies[^2]. One original company in the UK registered back in June 2021 for paying the team's salary and taxes[^3]. Another company in BVI registered in December 2021 for PCC to launch its $YARN legally[^4]. **[The PCC Team](./team.md)** currently consists of 8 full-time members of staff and 2 part-time members of staff.
 
 [^2]: 3 companies were mentioned in Carlini8's [interview by Lucky Trader](/posts/2022/02/25/3rd-party/lucky-trader).
 [^3]: The first company was mentioned many times in Carlini8's [interviews](/posts/tags/interview).
-[^4]: BVI company was mentioned in [interview by Lucky Trader](/posts/2022/02/25/3rd-party/lucky-trader), and time was mentioned in [interview by Talkenized](/posts/2022/04/27/3rd-party/talkenized). The $TOKEN has not released yet, "$TOKEN" here is a placeholder for it's to be launched token.
+[^4]: BVI company was mentioned in [interview by Lucky Trader](/posts/2022/02/25/3rd-party/lucky-trader), and time was mentioned in [interview by Talkenized](/posts/2022/04/27/3rd-party/talkenized).
 
 ## Collections 😺 {#collections}
 
 **PCC Universe has 4 main [Collections](../collections/index.md): Cats, Kittens, Grandmas, and Tier 2 (TBA). And 3 other [Collections](../collections/index.md): Purrnelope's Exslusives, KittyVault Purrks and Purrnelope's Gift.**
 
-The 4 main collections are classified into 3 tiers, which will yield different amounts of $TOKEN per day. Exclusives collection also yield $TOKEN.
+The 4 main collections are classified into 3 tiers, which will yield different amounts of $YARN per day. Exclusives collection also yield $YARN.
 
 <span className="wikiPostListImgR">
 
@@ -75,7 +75,7 @@ The 4 main collections are classified into 3 tiers, which will yield different a
 
 ### Exclusives <sup>YIELD</sup>
 
-**[Purrnelope's Exclusives](../collections/exclusives/index.md)** are $TOKEN yielding NFTs. There are 5 categories in Exclusives, the higher the rarity, different categories yield different $TOKEN amount.
+**[Purrnelope's Exclusives](../collections/exclusives/index.md)** are $YARN yielding NFTs. There are 5 categories in Exclusives, the higher the rarity, different categories yield different $YARN amount.
 
 Exclusives may receive extra perks in PCC Universe.
 
@@ -119,11 +119,11 @@ The new PCC Ambassadors role requires to have a .pcc.eth subdomain.
 
 </span>
 
-## $TOKEN 💰 {#token}
+## $YARN 💰 {#token}
 
-**Purrnelope's Token has not been released yet, "$TOKEN" here is a placeholder.**
+**$YARN is the official Purrnelope's Token.**
 
-NFTs from main [collections](../collections/index.md) will be able to yield $TOKEN. $TOKEN will be used for purchasing packs, community governance, etc. $TOKEN was mentioned a lot during [Carlini8's interview by Overpriced JPEGs](/posts/2022/03/30/3rd-party/overpriced-jpegs).
+NFTs from main [collections](../collections/index.md) will be able to yield $YARN. $YARN will be used for purchasing packs, community governance, etc. $YARN was mentioned a lot during [Carlini8's interview by Overpriced JPEGs](/posts/2022/03/30/3rd-party/overpriced-jpegs).
 
 ## Merch 🛍 {#merch}
 
@@ -185,9 +185,9 @@ Displate and Anime Short are still in progress, and these are mentioned in [Road
 
 ### Roadmap 1.0 Plus
 
-**KittyVault**, **KittyVault Purrks** Airdrops, 1st companions: **Kittens**, 2nd companions: **TBA**, **Tier 2 Collection**, **$TOKEN**, **.pcc.eth ENS subdomains** were not on the original roadmap 1.0 but added to the project later.
+**KittyVault**, **KittyVault Purrks** Airdrops, 1st companions: **Kittens**, 2nd companions: **TBA**, **Tier 2 Collection**, **$YARN**, **.pcc.eth ENS subdomains** were not on the original roadmap 1.0 but added to the project later.
 
-The KittyVault is waiting to be fractionlized once it's ready. KittyVault Purrks airdrops, 2nd companion, Tier 2 Collection, and $TOKEN are mentioned in [Roadmap 2.0](#roadmap-20), and will be tracked in the next Roadmap 2.0 section.
+The KittyVault is waiting to be fractionlized once it's ready. KittyVault Purrks airdrops, 2nd companion, Tier 2 Collection, and $YARN are mentioned in [Roadmap 2.0](#roadmap-20), and will be tracked in the next Roadmap 2.0 section.
 
 - 😼 KittyVault
 - ✅ Kittens: [2021-Q4](#2021-q4)
@@ -203,7 +203,7 @@ The KittyVault is waiting to be fractionlized once it's ready. KittyVault Purrks
 - ✅ Merch [2022-Q2](#2022-q2)
 - 🚙 Redeem for Physicals Completed: 1/6
 - 🛠 Tier 2 Collection
-- 🛠 $TOKEN
+- 🛠 $YARN
 
 Other items from Roadmap 2.0 will be added to the list upon completion or new updates from the team. Here's a map of Roadmap 2.0:
 

--- a/wiki/club/index.md
+++ b/wiki/club/index.md
@@ -119,7 +119,7 @@ The new PCC Ambassadors role requires to have a .pcc.eth subdomain.
 
 </span>
 
-## $YARN 💰 {#token}
+## $YARN 🧶 {#token}
 
 **$YARN is the official Purrnelope's Token.**
 
@@ -203,7 +203,7 @@ The KittyVault is waiting to be fractionlized once it's ready. KittyVault Purrks
 - ✅ Merch [2022-Q2](#2022-q2)
 - 🚙 Redeem for Physicals Completed: 1/6
 - 🛠 Tier 2 Collection
-- 🛠 $YARN
+- ✅ $YARN Token
 
 Other items from Roadmap 2.0 will be added to the list upon completion or new updates from the team. Here's a map of Roadmap 2.0:
 

--- a/wiki/collections/_tier2.md
+++ b/wiki/collections/_tier2.md
@@ -1,5 +1,5 @@
 **Tier 2 (TBA) in PCC Universe will be the equivalent of Meebits, Mutants from Punks and BAYC.** It is the second entry to the PCC Universe. And there are potentially 6 different version of Tier 2.
 
-The sale for Tier 2 has not been officially announced yet, and $TOKEN is heavily involved in acquiring them.
+The sale for Tier 2 has not been officially announced yet, and $YARN is heavily involved in acquiring them.
 
 > Some detail on Tier 2 was mentioned in [Roadmap 2.0](../club/index.md#roadmap-20) and [interivew by Overpriced JPEGs](/posts/2022/03/30/3rd-party/overpriced-jpegs#purrnelope-token-utility). And detail may change before it announced officially.

--- a/wiki/collections/cats/index.md
+++ b/wiki/collections/cats/index.md
@@ -33,11 +33,11 @@ Cats owners can access **Clubhouse** channel in [PCC Discord](http://discord.gg/
 
 Cats owners can claim their [.pcc.eth ENS Subdomains](../../ens/index.md) at [Claim Page](https://www.purrnelopescountryclub.com/claim/ens) of PCC Website.
 
-Cats owner using .pcc.eth subdomain names as Twitter & Discord display names will received **Ambassador** role in [PCC Discord](http://discord.gg/purrnelopescountryclub). 
+Cats owner using .pcc.eth subdomain names as Twitter & Discord display names will received **Ambassador** role in [PCC Discord](http://discord.gg/purrnelopescountryclub).
 
-### Earn $Token
+### Earn $YARN
 
-Cats are Tier 1 NFTs, will yield 10 $TOKENs per day per Cat.
+Cats are Tier 1 NFTs, will yield 10 $YARN per day per Cat.
 
 ### Redeem for KittlyVault Fractions
 

--- a/wiki/collections/exclusives/index.md
+++ b/wiki/collections/exclusives/index.md
@@ -3,7 +3,7 @@ sidebar_position: 35
 title: 🛩 Purrnelope's Exclusives
 sidebar_label: 🛩 Exclusives
 image: /img/cover/pcc-exclusives.jpg
-description: Purrnelope's Exclusives are $TOKEN Yielding NFTs and may receive extra perks in PCC Universe.
+description: Purrnelope's Exclusives are $YARN Yielding NFTs and may receive extra perks in PCC Universe.
 ---
 
 🛩
@@ -15,19 +15,19 @@ description: Purrnelope's Exclusives are $TOKEN Yielding NFTs and may receive ex
 
 ## What are PCC Exclusives
 
-Purrnelope's Exclusives are $TOKEN Yielding NFTs and may receive extra perks in PCC Universe.
+Purrnelope's Exclusives are $YARN Yielding NFTs and may receive extra perks in PCC Universe.
 
-### $Token Yield
+### $YARN Yield
 
-There are 5 categories in Exclusives, the higher the rarity, different categories yield different $TOKEN amount.
+There are 5 categories in Exclusives, the higher the rarity, different categories yield different $YARN amount.
 
-| Category | Type        | Daily $TOKEN Yield |
-| :------- | :---------- | :----------------- |
-| CAT I    | Float       | 5                  |
-| CAT II   | Golf Cart   | 10                 |
-| CAT III  | Jeep        | 25                 |
-| CAT IV   | Super Car   | 50                 |
-| CAT V    | Private Jet | 100                |
+| Category | Type        | Daily $YARN Yield |
+| :------- | :---------- | :---------------- |
+| CAT I    | Float       | 5                 |
+| CAT II   | Golf Cart   | 10                |
+| CAT III  | Jeep        | 25                |
+| CAT IV   | Super Car   | 50                |
+| CAT V    | Private Jet | 100               |
 
 ### Exclusive Airdrops
 

--- a/wiki/collections/grandmas/index.md
+++ b/wiki/collections/grandmas/index.md
@@ -37,12 +37,6 @@ Grandmas owners can access **Clubhouse** channel in [PCC Discord](http://discord
 
 Grandmas are Tier 3 NFTs, will earn 1 $YARN per day per Grandma.
 
-:::info
-
-Details for Tiers & $YARN has not been released yet.
-
-:::
-
 ### Redeem for KittyVault Fractions
 
 Once the [KittyVault](../../kittyvault/index.md) is fractionalized, Grandmas can be redeemed(burned) for [KittyBank Token](../../kittyvault/index.md#kittybank-token-token).

--- a/wiki/collections/grandmas/index.md
+++ b/wiki/collections/grandmas/index.md
@@ -33,13 +33,13 @@ All unclaimed Grandmas will be minted by the team.
 
 Grandmas owners can access **Clubhouse** channel in [PCC Discord](http://discord.gg/purrnelopescountryclub).
 
-### Earn $Token
+### Earn $YARN
 
-Grandmas are Tier 3 NFTs, will earn 1 $TOKEN per day per Grandma.
+Grandmas are Tier 3 NFTs, will earn 1 $YARN per day per Grandma.
 
 :::info
 
-Details for Tiers & $TOKEN has not been released yet.
+Details for Tiers & $YARN has not been released yet.
 
 :::
 

--- a/wiki/collections/index.md
+++ b/wiki/collections/index.md
@@ -3,7 +3,7 @@ title: PCC Collections
 sidebar_label: 😺 Collections
 sidebar_position: 20
 image: /img/cover/pcc-collections.jpg
-description: "Cats, Kittens, Grandmas, Exclusives, KittyVault Purrks, Gifts and more collections coming to PCC Universe."
+description: 'Cats, Kittens, Grandmas, Exclusives, KittyVault Purrks, Gifts and more collections coming to PCC Universe.'
 ---
 
 import Cats from './\_cats.md';
@@ -17,7 +17,7 @@ import KVPurrks from './\_kittyvault-purrks.md';
 
 **PCC Universe has 4 main collections: Cats, Kittens, Grandmas, and Tier 2 (TBA) that are cat members of the country club. And 3 other Collections: Purrnelope's Exslusives, KittyVault Purrks and Purrnelope's Gift.**
 
-The 4 main collections are classified into 3 tiers, which will yield different amounts of $TOKEN per day. Exclusives collection also yield $TOKEN.
+The 4 main collections are classified into 3 tiers, which will yield different amounts of $YARN per day. Exclusives collection also yield $YARN.
 
 ## Main Collections
 
@@ -27,15 +27,15 @@ Cats, Kittens, Grandmas, Tier 2s (TBA) are 4 main collections in PCC Universe.
 
 ### Tiers
 
-Main collections are classified into 3 tiers, which will yield different amounts of $TOKEN perday.
+Main collections are classified into 3 tiers, which will yield different amounts of $YARN perday.
 
-- Tier 1: will yield 10 $TOKENs per day.
-- Tier 2: will yield 5 $TOKENs per day.
-- Tier 3: will yield 1 $TOKEN per day.
+- Tier 1: will yield 10 $YARN per day.
+- Tier 2: will yield 5 $YARN per day.
+- Tier 3: will yield 1 $YARN per day.
 
 :::info
 
-Details for Tiers & $TOKEN has not been released yet.
+Details for Tiers & $YARN will be documented and updated accordingly following the team's updates.
 
 :::
 
@@ -79,7 +79,7 @@ Details for Tiers & $TOKEN has not been released yet.
 
 [![](./exclusives/assets/pcc-exclusives.jpg)](./exclusives/index.md)
 
-[Purrnelope's Exclusives](./exclusives/index.md) are $TOKEN Yielding NFTs. There are 5 categories in Exclusives, the higher the rarity, different categories yield different $TOKEN amount.
+[Purrnelope's Exclusives](./exclusives/index.md) are $YARN Yielding NFTs. There are 5 categories in Exclusives, the higher the rarity, different categories yield different $YARN amount.
 
 Exclusives may receive extra perks in PCC Universe.
 

--- a/wiki/collections/kittens/index.md
+++ b/wiki/collections/kittens/index.md
@@ -21,7 +21,7 @@ Purrnelope's Kittens is the 2nd collection in PCC Universe with 10,000 randomly 
 
 ![](./assets/claim-kittens.jpg)
 
-Kittens are claimed with [Kitten Basket](../kittyvault-purrks/2-kitten-basket.md), 1 Kitten Basket for 1 Kitten. Public Kittens Claim opened on Nov 15, 2021. Unredeemed Kitten Baskets were pulled back on Dec 20, 2021. 
+Kittens are claimed with [Kitten Basket](../kittyvault-purrks/2-kitten-basket.md), 1 Kitten Basket for 1 Kitten. Public Kittens Claim opened on Nov 15, 2021. Unredeemed Kitten Baskets were pulled back on Dec 20, 2021.
 
 All unclaimed Kittens will be minted by the team. And will be used in giveaways. [^1]
 
@@ -33,15 +33,9 @@ Kittens `#1 - #20` are not revealed. They are reserved for The Team for mysterio
 
 Kittens owners can access **Clubhouse** channel in [PCC Discord](http://discord.gg/purrnelopescountryclub).
 
-### Earn $Token
+### Earn $YARN
 
-Kittens are Tier 3 NFTs, will earn 1 $TOKEN per day per Kitten.
-
-:::info
-
-Details for Tiers & $TOKEN has not been released yet.
-
-:::
+Kittens are Tier 3 NFTs, will earn 1 $YARN per day per Kitten.
 
 ### Redeem for KittyVault Fractions
 
@@ -131,12 +125,12 @@ function internalMint(address _to, uint256 _quantity) private {
 function getRandomNumber(uint256 maxValue, uint256 salt) private view returns(uint256) {
     if (maxValue == 0)
         return 0;
-        
+
     uint256 seed =
         uint256(
             keccak256(
                 abi.encodePacked(
-                        block.difficulty +	
+                        block.difficulty +
                         ((uint256(keccak256(abi.encodePacked(tx.origin, msg.sig)))) / (block.timestamp)) +
                         block.number +
                         salt
@@ -156,7 +150,6 @@ This function only accepts Kittens mint by the [KittyVault Purrks](../kittyvault
 This was used for mint Kittens using the Kitten Basket Purrks.
 
 > This function is the same as the [Grandmas Contract](../grandmas/index.md#contract)
-
 
 <details><summary>See Code</summary>
 

--- a/wiki/collections/kittyvault-purrks/3-model-cat.md
+++ b/wiki/collections/kittyvault-purrks/3-model-cat.md
@@ -37,7 +37,7 @@ Redeem for [KittyVault](../../kittyvault/index.md) Fractions will open in the fu
 ## Learn more
 
 - Video: [3D Model: Explained!](/posts/explained/202112-3d-model)
-- PurrCast: [PurrCast: 3D Models, ENS subdomains, $Token, The Future](/posts/2022/01/19/purrcast/)
+- PurrCast: [PurrCast: 3D Models, ENS subdomains, $YARN, The Future](/posts/2022/01/19/purrcast/)
 - Merch: [PCC Model Cat](../../merch/pcc-model-cat.md)
 
 ## Events
@@ -97,4 +97,4 @@ Redeem for [KittyVault](../../kittyvault/index.md) Fractions will open in the fu
 
   </details>
 
-[^1]: From [PurrCast: 3D Models, ENS subdomains, $Token, The Future](/posts/2022/01/19/purrcast/)
+[^1]: From [PurrCast: 3D Models, ENS subdomains, $YARN, The Future](/posts/2022/01/19/purrcast/)

--- a/wiki/kittyvault/index.md
+++ b/wiki/kittyvault/index.md
@@ -29,7 +29,7 @@ The KittyVault is 100,000 fractions, 10,000 held by the team for liquidity, and 
 
 ### KittyBank Token {#token}
 
-**The KittyBank Token**, aka KittyVault Token, is different from the $TOKEN.
+**The KittyBank Token**, aka KittyVault Token, is different from $YARN.
 
 [PCC Cats](../collections/cats/index.md), [Kittens](../collections/kittens/index.md), Cat Grandmas and other 6 [KittyVault Purrks](../collections/kittyvault-purrks/index.md) will be able to be redeemed for KittyBank Token that represent shares of the KittyVault. That KittyBank Token will be tradable for 1/100,000 of the Vault's value.
 


### PR DESCRIPTION
This PR replaces the `$TOKEN`, which is a placeholder, as `$YARN` since it's now the official token name. Note that this only replaces the name of the token while additional information about `$YARN` will be documented and updated in following PRs.